### PR TITLE
start omniNames before running the tests

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -84,7 +84,7 @@ c['builders'].append(
 
 ### rock-core
 
-rock.StandardSetup("rock-core", "https://github.com/rock-core/buildconf")
+rock.StandardSetup(c, "rock-core", "https://github.com/rock-core/buildconf")
 c['schedulers'].append(
     schedulers.ForceScheduler(
         name="cache-force",

--- a/master/rock.py
+++ b/master/rock.py
@@ -292,6 +292,15 @@ def Build(factory):
         name="Building the workspace")
 
     Barrier(factory, "test")
+    factory.addStep(steps.FileDownload(name="copy omniNames startup script",
+        workerdest="/buildbot/start-omniNames",
+        mastersrc="start-omniNames",
+        mode=0o755,
+        haltOnFailure=True))
+    factory.addStep(steps.ShellCommand(name="start omniNames for tests",
+        command=["/buildbot/start-omniNames"],
+        haltOnFailure=True,
+        usePTY=True))
     AutoprojStep(factory, "ci", "test", "--interactive=f", "-k", p,
         name="Running unit tests")
 

--- a/master/start-omniNames
+++ b/master/start-omniNames
@@ -1,0 +1,11 @@
+#! /bin/bash -e
+
+sudo apt-get update
+sudo apt-get install -y omniorb-nameserver omniorb
+
+( nohup setsid /usr/bin/omniNames -start -always -datadir /tmp -errlog /tmp/omniNames-errors.log ) &
+
+while ! /usr/bin/nameclt list; do
+    sleep 1
+done
+


### PR DESCRIPTION
The hard part here was to make omniNames "hidden" from view for buildbot. Just setsid was not enough (don't know why). It only started working with also nohup.