### PR TITLE
remove qtbindings from the list of precompiled gems

### DIFF
--- a/master/rock.py
+++ b/master/rock.py
@@ -190,7 +190,7 @@ def UpdateImportCache(factory):
             CACHE_IMPORT_DIR, "--interactive=f", "-k",
             "--gems",
             util.Interpolate("--gems-compile-force=%(prop:gems_compile_force:#?|t|f)s"),
-            "--gems-compile", "qtbindings", "rice+ruby/lib", "ffi"
+            "--gems-compile", "rice+ruby/lib", "ffi"
         ],
         locks=[cache_import_lock.access('exclusive')],
         haltOnFailure=True


### PR DESCRIPTION
qtbindings creates extensions that point to shared libraries, and is
therefore sensitive to LD_LIBRARY_PATH/RPATH. There's no easy way I
see to fix that, so disable for now.

It does not affect the update speed since qtbindings is already prebuilt
in the worker docker