### PR TITLE
fine tuning

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -40,7 +40,9 @@ c['workers'] = [
     rock.BuildWorker('build',
         image="gcr.io/{0}/buildbot-worker".format(info['project']),
         kube_config=k8s_config,
-        masterFQDN=SLAVE_TO_MASTER_FQDN)
+        masterFQDN=SLAVE_TO_MASTER_FQDN,
+        max_builds=1,
+        build_wait_timeout=0)
 ]
 
 # 'protocols' contains information about protocols which master will use for

--- a/master/seed-config.yml
+++ b/master/seed-config.yml
@@ -1,1 +1,2 @@
 USE_OCL: false
+rock_test_boost_format: JUNIT


### PR DESCRIPTION
These are small configuration changes we applied on our cluster.
- change the build worker to only ever have one build per container
- make sure rock's boost tests generate JUnit results (depends on a PR on rock.core)