### PR TITLE
move the system nodes to preemptible

### DIFF
--- a/infrastructure/gke/cluster.tf
+++ b/infrastructure/gke/cluster.tf
@@ -27,6 +27,7 @@ resource "google_container_node_pool" "system" {
     node_config {
         machine_type = "g1-small"
         disk_size_gb = "10"
+        preemptible = true
 
         labels = {
             system-role = "1"

--- a/infrastructure/k8s/cache-apt.tf
+++ b/infrastructure/k8s/cache-apt.tf
@@ -61,6 +61,11 @@ resource "kubernetes_deployment" "cache-apt" {
                         mount_path = "/var/cache/apt-cacher-ng"
                         name = "cache-apt"
                     }
+                    resources {
+                        requests {
+                            cpu = "0"
+                        }
+                    }
                 }
 
                 volume {

--- a/infrastructure/k8s/cache-autoproj-build.tf
+++ b/infrastructure/k8s/cache-autoproj-build.tf
@@ -107,6 +107,12 @@ resource "kubernetes_deployment" "cache-autoproj-build-server" {
                     image = "gcr.io/${var.project}/volume-nfs"
                     image_pull_policy = "Always"
 
+                    resources {
+                        requests {
+                            cpu = "0"
+                        }
+                    }
+
                     security_context {
                         privileged = true
                     }

--- a/infrastructure/k8s/cache-gem.tf
+++ b/infrastructure/k8s/cache-gem.tf
@@ -13,7 +13,7 @@ resource "kubernetes_service" "cache-gem" {
 
     spec {
         selector = {
-            app = "${kubernetes_pod.cache-gem.metadata.0.labels.app}"
+            app = "${kubernetes_deployment.cache-gem.metadata.0.labels.app}"
         }
         port {
             name = "cache-gem"
@@ -29,7 +29,7 @@ resource "google_compute_disk" "cache-gem" {
     size  = "10"
 }
 
-resource "kubernetes_pod" "cache-gem" {
+resource "kubernetes_deployment" "cache-gem" {
     metadata {
         name = "cache-gem"
         labels = {
@@ -38,19 +38,37 @@ resource "kubernetes_pod" "cache-gem" {
     }
 
     spec {
-        container {
-            image = "gcr.io/${var.project}/cache-gem"
-            image_pull_policy = "Always"
-            name = "cache-gem"
-            volume_mount {
-                mount_path = "/var/cache/gem"
-                name = "cache-gem"
+        replicas = 1
+
+        selector {
+            match_labels = {
+                app = "cache-gem"
             }
         }
-        volume {
-            name = "cache-gem"
-            gce_persistent_disk {
-                pd_name = "${google_compute_disk.cache-gem.name}"
+
+        template {
+            metadata {
+                labels = {
+                    app = "cache-gem"
+                }
+            }
+
+            spec {
+                container {
+                    image = "gcr.io/${var.project}/cache-gem"
+                    image_pull_policy = "Always"
+                    name = "cache-gem"
+                    volume_mount {
+                        mount_path = "/var/cache/gem"
+                        name = "cache-gem"
+                    }
+                }
+                volume {
+                    name = "cache-gem"
+                    gce_persistent_disk {
+                        pd_name = "${google_compute_disk.cache-gem.name}"
+                    }
+                }
             }
         }
     }

--- a/infrastructure/k8s/cache-gem.tf
+++ b/infrastructure/k8s/cache-gem.tf
@@ -62,6 +62,11 @@ resource "kubernetes_deployment" "cache-gem" {
                         mount_path = "/var/cache/gem"
                         name = "cache-gem"
                     }
+                    resources {
+                        requests {
+                            cpu = "0"
+                        }
+                    }
                 }
                 volume {
                     name = "cache-gem"


### PR DESCRIPTION
This is mostly to cut costs: the main cost of our cluster so far *are*
the system nodes. The price with preemptible is 3x lower, and we
don't really care (once the connection between the master and
slave is created, we don't rely on the control pods)