### PR TITLE
Changes for other types of workers

### DIFF
--- a/containers/buildbot-master/Dockerfile
+++ b/containers/buildbot-master/Dockerfile
@@ -9,3 +9,10 @@ RUN apk add zlib-dev libjpeg-turbo-dev python3-dev build-base && \
     pip3 --no-cache-dir install 'txrequests' buildbot-badges flask \
         buildbot-wsgi_dashboards && \
     apk del zlib-dev libjpeg-turbo-dev python3-dev build-base
+
+RUN apk add py3-libvirt
+
+COPY 'configure-host-and-exec' '/usr/local/bin'
+
+USER buildbot
+CMD ["/usr/local/bin/configure-host-and-exec", "dumb-init", "/usr/src/buildbot/docker/start_buildbot.sh"]

--- a/containers/buildbot-master/configure-host-and-exec
+++ b/containers/buildbot-master/configure-host-and-exec
@@ -1,0 +1,9 @@
+#! /bin/sh
+#
+# Needed for the libvirt worker to access libvirt from the host
+#
+# See https://github.com/docker/for-linux/issues/264 for why this is so
+# difficult, and for the workaround itself
+
+echo -e "`/sbin/ip route|awk '/default/ { print $3 }'`" > /var/lib/buildbot/host_ip
+exec "$@"

--- a/master/rock.py
+++ b/master/rock.py
@@ -287,6 +287,8 @@ ROCK_SELECTED_FLAVOR: {flavor}
         commands=[
             util.ShellArg(command=["wget", bootstrap_script_url],
                 logfile="download", haltOnFailure=True),
+            util.ShellArg(command="mkdir -p /home/buildbot/.bundle", logfile="bundle-config",
+                haltOnFailure=True),
             util.ShellArg(command=bundle_config, logfile="bundle-config",
                 haltOnFailure=True),
             util.ShellArg(command=[

--- a/master/rock.py
+++ b/master/rock.py
@@ -446,9 +446,10 @@ def StandardSetup(c, name, buildconf_url,
 
     c['builders'].append(
         util.BuilderConfig(name=f"{name}-build",
-        workernames=build_workers,
-        factory=build_factory,
-        properties={ 'parallel_build_level': parallel_build_level })
+            workernames=build_workers,
+            factory=build_factory,
+            properties={ 'parallel_build_level': parallel_build_level }
+        )
     )
 
     return [import_cache_factory, build_factory]

--- a/master/rock.py
+++ b/master/rock.py
@@ -292,7 +292,7 @@ ROCK_SELECTED_FLAVOR: {flavor}
             util.ShellArg(command=bundle_config, logfile="bundle-config",
                 haltOnFailure=True),
             util.ShellArg(command=[
-                "ruby", "autoproj_bootstrap",
+                util.Interpolate("%(prop:ruby:-ruby)s"), "autoproj_bootstrap",
                 "--seed-config=seed-config.yml",
                 "--no-interactive", *bootstrap_options, vcstype, buildconf_url,
                 util.Interpolate(f"branch=%(prop:branch:-{buildconf_default_branch})s")],
@@ -328,7 +328,7 @@ def Build(factory):
         name="Running unit tests")
 
     AutoprojStep(factory, "ci", "process-test-results", "--interactive=f",
-        "--xunit-viewer=/usr/local/bin/xunit-viewer",
+        util.Interpolate("--xunit-viewer=%(prop:xunit-viewer:-/usr/local/bin/xunit-viewer)s"),
         name="Postprocess test results",
         ifReached="test")
     AutoprojStep(factory, "ci", "cache-push", "--interactive=f", CACHE_BUILD_DIR,


### PR DESCRIPTION
These are changes I've brought in to handle another type of worker than the buildbot-worker container.

In our use-case, it allowed us to connect to a worker that is running on the master (hence the host IP detection), as well as a Debian 9 where both ruby and xunit-viewer are in different paths.