### PR TITLE
expand on gem precompilation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ The build steps assume that there is an import cache mounted in
 `/var/cache/autoproj/import` in the slave container. One may create an import
 cache update builder to update the cache.
 
+The import cache creation supports using `gem-compiler` to prebuild gems,
+speeding the update stage significantly (the update step is the longer step on
+incremental builds). Which gems get precompiled is controlled by the
+`gem_compile` array argument in `StandardSetup` or `ImportCache` (see
+[rock.py](master/rock.py)). This work out of the box for most gems, but more
+complicated gems don't work at all, or work with significant tuning:
+
+- the `rice` gem can't be precompiled for now
+- the `qtbindings` gem (qt-ruby bindings) need to be tuned during
+  precompilation. Add `qtbindings[+lib/2.5/*.so.?-lib/2.5/*.so]` to
+  `gem_compile`, and add `99-qtbindings-x86_64.rb` to the `overrides_path` array
+  argument. The gem won't be functional otherwise.
+
 ### Build cache
 
 Successfully built packages are cached so as to reduce the build cycle (dramatically)

--- a/master/99-qtbindings-x86_64.rb
+++ b/master/99-qtbindings-x86_64.rb
@@ -1,0 +1,7 @@
+# Necessary to use the prebuilt qtbindings. Without this, the RPATHs being
+# wrong, the shared libraries can't find each other
+Autoproj.env_add_path(
+    'LD_LIBRARY_PATH',
+    '/home/buildbot/.local/share/autoproj/gems/ruby/2.5.0/gems/qtbindings-4.8.6.5-x86_64-linux/lib/2.5'
+)
+                      

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -87,7 +87,9 @@ c['builders'].append(
 
 ### rock-core
 
-rock.StandardSetup(c, "rock-core", "https://github.com/rock-core/buildconf")
+rock.StandardSetup(c, "rock-core", "https://github.com/rock-core/buildconf",
+                   gem_compile=['ffi', 'qtbindings[+lib/2.5/*.so.?-lib/2.5/*.so'],
+                   overrides_path=['99-qtbindings-x86_64.rb'])
 c['schedulers'].append(
     schedulers.ForceScheduler(
         name="cache-force",

--- a/master/rock.py
+++ b/master/rock.py
@@ -173,7 +173,7 @@ def CleanBuildCache(factory):
         name="Check result",
         command=["find", util.Interpolate(f"{CACHE_BUILD_BASE_DIR}/%(prop:target_buildername)s")]))
 
-def UpdateImportCache(factory):
+def UpdateImportCache(factory, gem_compile=["ffi"]):
     factory.addStep(steps.ShellCommand(
         name="Install gem-compiler to cache the precompiled gems",
         command=[
@@ -190,7 +190,7 @@ def UpdateImportCache(factory):
             CACHE_IMPORT_DIR, "--interactive=f", "-k",
             "--gems",
             util.Interpolate("--gems-compile-force=%(prop:gems_compile_force:#?|t|f)s"),
-            "--gems-compile", "rice+ruby/lib", "ffi"
+            "--gems-compile", gem_compile
         ],
         locks=[cache_import_lock.access('exclusive')],
         haltOnFailure=True
@@ -493,6 +493,7 @@ def StandardSetup(c, name, buildconf_url,
                   properties={},
                   tests=True,
                   test_utilities=['omniorb', 'x11'],
+                  gem_compile=["ffi"],
                   autoproj_url=AUTOPROJ_GIT_URL,
                   autobuild_url=AUTOBUILD_GIT_URL,
                   autoproj_ci_url=AUTOPROJ_CI_GIT_URL):
@@ -517,7 +518,7 @@ def StandardSetup(c, name, buildconf_url,
               autoproj_ci_url=autoproj_ci_url)
 
     Update(import_cache_factory, import_timeout=import_timeout)
-    UpdateImportCache(import_cache_factory)
+    UpdateImportCache(import_cache_factory, gem_compile=gem_compile)
 
     c['builders'].append(
         util.BuilderConfig(name=f"{name}-import-cache",

--- a/master/rock.py
+++ b/master/rock.py
@@ -235,6 +235,7 @@ def Bootstrap(factory, buildconf_url,
               autobuild_branch=None,
               autoproj_ci_branch=None,
               seed_config_path=None,
+              overrides_file_paths=[],
               flavor="master",
               tests=True,
               build_cache_max_size_GB=None,
@@ -340,6 +341,14 @@ ROCK_SELECTED_FLAVOR: {flavor}
                 logfile="plugins", haltOnFailure=True)
         ] + test_steps + cache_cleanup_steps,
         haltOnFailure=True))
+
+    if overrides_file_paths:
+        for file in overrides_file_paths:
+            factory.addStep(steps.FileDownload(
+                name=f"copy user-provided overrides file {file}",
+                workerdest=f"autoproj/overrides.d/{file}",
+                mastersrc=file,
+                haltOnFailure=True))
 
 def Build(factory, tests=True, test_utilities=['omniorb', 'x11'], build_timeout=1200):
     p = util.Interpolate('-p%(prop:parallel_build_level:-1)s')
@@ -473,6 +482,7 @@ def StandardSetup(c, name, buildconf_url,
                   autobuild_branch=None,
                   autoproj_ci_branch=None,
                   seed_config_path=None,
+                  overrides_file_paths=[],
                   flavor="master",
                   import_workers=["import-cache"],
                   build_workers=["build"],
@@ -500,6 +510,7 @@ def StandardSetup(c, name, buildconf_url,
               autobuild_branch=autobuild_branch,
               autoproj_ci_branch=autoproj_ci_branch,
               seed_config_path=seed_config_path,
+              overrides_file_paths=overrides_file_paths,
               flavor=flavor,
               autoproj_url=autoproj_url,
               autobuild_url=autobuild_url,
@@ -527,6 +538,7 @@ def StandardSetup(c, name, buildconf_url,
               autobuild_branch=autobuild_branch,
               autoproj_ci_branch=autoproj_ci_branch,
               seed_config_path=seed_config_path,
+              overrides_file_paths=overrides_file_paths,
               flavor=flavor,
               build_cache_max_size_GB=build_cache_max_size_GB,
               autoproj_url=autoproj_url,


### PR DESCRIPTION
Pass the list of gems to precompile as argument, and add documentation about the feature.

Add an overrides file that can be used to ensure the precompiled qtbindings gem can be used
(to set LD_LIBRARY_PATH). This is a bit of a hack, but simplifies the container quite a lot
(we had to precompile qtbindings in them to speed updates up significantly)