### PR TITLE
allow controlling the parallel test level independently

### DIFF
--- a/master/rock.py
+++ b/master/rock.py
@@ -378,6 +378,7 @@ def Build(factory, tests=True, test_utilities=['omniorb', 'x11'], build_timeout=
         if 'x11' in test_utilities:
             wrapper=['xvfb-run']
 
+        p = util.Interpolate('-p%(prop:parallel_test_level:-1)s')
         AutoprojStep(factory, "ci", "test", "--interactive=f", "-k", p,
             name="Running unit tests", wrapper=wrapper)
 
@@ -487,6 +488,7 @@ def StandardSetup(c, name, buildconf_url,
                   import_workers=["import-cache"],
                   build_workers=["build"],
                   parallel_build_level=4,
+                  parallel_test_level=1,
                   import_timeout=1200,
                   build_timeout=1200,
                   build_cache_max_size_GB=None,
@@ -551,7 +553,11 @@ def StandardSetup(c, name, buildconf_url,
           tests=tests, test_utilities=test_utilities)
     BuildReport(build_factory)
 
-    build_properties = { 'parallel_build_level': parallel_build_level }
+    build_properties = {
+        'parallel_build_level': parallel_build_level,
+        'parallel_test_level': parallel_test_level
+    }
+
     build_properties.update(properties)
     c['builders'].append(
         util.BuilderConfig(name=f"{name}-build",


### PR DESCRIPTION
Syskit-based Rock oroGen tests cannot currently be executed in parallel,
as they share the same task name (and still use a name service)